### PR TITLE
CI: Add MinGW builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,15 +105,19 @@ jobs:
         include:
         - qt_version: 5.15.2
           qt_arch: win32_msvc2019
+          cmake_args: -G "Visual Studio 16 2019" -A Win32
         - qt_version: 6.8.1
           qt_arch: win64_msvc2022_64
+          cmake_args: -G "Visual Studio 17 2022" -A x64
         - qt_version: 5.15.2
           qt_arch: win32_mingw81
           qt_tools: tools_mingw,qt.tools.win32_mingw810
+          cmake_args: -G "MinGW Makefiles"
           mingw_dir: mingw810_32
         - qt_version: 6.8.1
           qt_arch: win64_mingw
           qt_tools: tools_mingw1310,qt.tools.win64_mingw1310
+          cmake_args: -G "MinGW Makefiles"
           mingw_dir: mingw1310_64
 
     defaults:
@@ -143,6 +147,6 @@ jobs:
         patch -p1 < ../../laf-msvc-dynamic-runtime.patch
         popd
         popd
-        cmake -B build -DCMAKE_BUILD_TYPE=Release
+        cmake -B build -DCMAKE_BUILD_TYPE=Release ${{ matrix.cmake_args }}
         cmake --build build --config Release
         cmake --install build --config Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,23 +98,27 @@ jobs:
 
   windows:
     name: Windows (Qt ${{ matrix.qt_version }}, ${{ matrix.qt_arch }})
-    runs-on: windows-latest
+    runs-on: windows-${{ matrix.windows_version }}
 
     strategy:
       matrix:
         include:
-        - qt_version: 5.15.2
+        - windows_version: 2019
+          qt_version: 5.15.2
           qt_arch: win32_msvc2019
           cmake_args: -G "Visual Studio 16 2019" -A Win32
-        - qt_version: 6.8.1
+        - windows_version: 2022
+          qt_version: 6.8.1
           qt_arch: win64_msvc2022_64
           cmake_args: -G "Visual Studio 17 2022" -A x64
-        - qt_version: 5.15.2
+        - windows_version: 2019
+          qt_version: 5.15.2
           qt_arch: win32_mingw81
           qt_tools: tools_mingw,qt.tools.win32_mingw810
           cmake_args: -G "MinGW Makefiles"
           mingw_dir: mingw810_32
-        - qt_version: 6.8.1
+        - windows_version: 2022
+          qt_version: 6.8.1
           qt_arch: win64_mingw
           qt_tools: tools_mingw1310,qt.tools.win64_mingw1310
           cmake_args: -G "MinGW Makefiles"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,12 +64,10 @@ jobs:
       matrix:
         include:
         - macos_version: 14
-          qt_version: 5
-          qt_exact_version: 5.15.2
+          qt_version: 5.15.2
           architectures: x86_64
         - macos_version: 15
-          qt_version: 6
-          qt_exact_version: 6.8.1
+          qt_version: 6.8.1
           architectures: x86_64;arm64
 
     steps:
@@ -86,7 +84,7 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: ${{ matrix.qt_exact_version }}
+        version: ${{ matrix.qt_version }}
         arch: clang_64
         cache: true
 
@@ -99,20 +97,24 @@ jobs:
         sudo cmake --install build --config Release
 
   windows:
-    name: Windows (${{ matrix.arch }}-bit, Qt ${{ matrix.qt_version_major }})
+    name: Windows (Qt ${{ matrix.qt_version }}, ${{ matrix.qt_arch }})
     runs-on: windows-latest
 
     strategy:
       matrix:
         include:
         - qt_version: 5.15.2
-          qt_version_major: 5
-          qt_arch: win64_msvc2019_64
-          arch: 32
+          qt_arch: win32_msvc2019
         - qt_version: 6.8.1
-          qt_version_major: 6
           qt_arch: win64_msvc2022_64
-          arch: 64
+        - qt_version: 5.15.2
+          qt_arch: win32_mingw81
+          qt_tools: tools_mingw,qt.tools.win32_mingw810
+          mingw_dir: mingw810_32
+        - qt_version: 6.8.1
+          qt_arch: win64_mingw
+          qt_tools: tools_mingw1310,qt.tools.win64_mingw1310
+          mingw_dir: mingw1310_64
 
     defaults:
       run:
@@ -129,6 +131,7 @@ jobs:
       with:
         version: ${{ matrix.qt_version }}
         arch: ${{ matrix.qt_arch }}
+        tools: "${{ matrix.qt_tools }}"
         cache: true
 
     - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,9 +147,13 @@ jobs:
         pushd aseprite
         patch -p1 < ../aseprite-fix-zlib-include.patch
         patch -p1 < ../aseprite-msvc-dynamic-runtime.patch
-        pushd laf
-        patch -p1 < ../../laf-msvc-dynamic-runtime.patch
         popd
+        pushd aseprite/laf
+        patch -p1 < ../../laf-msvc-dynamic-runtime.patch
+        patch -p1 < ../../laf-include-cstdint.patch
+        popd
+        pushd aseprite/third_party/cityhash
+        patch -p1 < ../../../cityhash-fix-byteswap.patch
         popd
         cmake -B build -DCMAKE_BUILD_TYPE=Release ${{ matrix.cmake_args }}
         cmake --build build --config Release

--- a/cityhash-fix-byteswap.patch
+++ b/cityhash-fix-byteswap.patch
@@ -1,0 +1,13 @@
+diff --git a/src/city.cc b/src/city.cc
+index 41cd5ee..a362d8c 100644
+--- a/src/city.cc
++++ b/src/city.cc
+@@ -47,7 +47,7 @@ static uint32 UNALIGNED_LOAD32(const char *p) {
+   return result;
+ }
+ 
+-#ifdef _MSC_VER
++#ifdef _WIN32
+ 
+ #include <stdlib.h>
+ #define bswap_32(x) _byteswap_ulong(x)

--- a/laf-include-cstdint.patch
+++ b/laf-include-cstdint.patch
@@ -1,0 +1,12 @@
+diff --git a/base/win/ver_query_values.cpp b/base/win/ver_query_values.cpp
+index 71df1a7..88944cf 100644
+--- a/base/win/ver_query_values.cpp
++++ b/base/win/ver_query_values.cpp
+@@ -12,6 +12,7 @@
+ 
+ #include "base/string.h"
+ 
++#include <cstdint>
+ #include <cstdio>
+ #include <string_view>
+ #include <vector>


### PR DESCRIPTION
This won't work yet, at the least because we still need to figure out how to make CMake use the installed MinGW.

This also fixes the Windows 32-bit build to actually build against a 32-bit Qt.